### PR TITLE
Ensure TCP socket; fixes cassandra-cql for OS X

### DIFF
--- a/Database/Cassandra/CQL.hs
+++ b/Database/Cassandra/CQL.hs
@@ -263,7 +263,7 @@ connectIfNeeded pool session =
         else do
             let (host, service) = sesServer session
             ais <- getAddrInfo (Just defaultHints { addrSocketType = Stream })
-                               (Just  host)
+                               (Just host)
                                (Just service)
             mSocket <- foldM (\mSocket ai -> do
                     case mSocket of


### PR DESCRIPTION
On OS X, `getAddrInfo` seems to return `DGRAM` before `STREAM`, hence the connection refused errors mentioned in issue #1. This patch should fix this, and is tested ok on OS X with the latest `haskell-platform`. Unfortunately, I don't have any other environments readily available for more testing.
