### PR TITLE
A more correct mapping for ByteString

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 dist/
 cabal.sandbox.config
 .cabal-sandbox/
+dist-newstyle/
+cabal.project.local

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog for [`cassandra-cql` package](https://hackage.haskell.org/package/cassandra-cql-0.5.0.0)
 
+## 0.6
+ * BREAKING: The ByteString type now gets mapped to Cassandra blobs instead
+   of ASCII. Please update all your use of (ByteString/'ascii') to use the
+   Ascii newtype wrapper. The Blob newtype has been removed, because it
+   introduces no new meaning.
+
 ## 0.5.0.2
  * Fix incorrect upper bound for base.
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings, DataKinds #-}
 
-import Control.Monad.CatchIO
+import Control.Monad.Catch
 import Control.Monad.Trans (liftIO)
 import Data.Int
 import qualified Data.List as L
@@ -229,7 +229,7 @@ ignoreDropFailure :: Cas () -> Cas ()
 ignoreDropFailure code = code `catch` \exc -> case exc of
     ConfigError _ _ -> return ()  -- Ignore the error if the table doesn't exist
     Invalid _ _ -> return ()
-    _               -> throw exc
+    _               -> throwM exc
 
 allTests :: TestTree
 allTests = testGroup "All Tests" [tupleTests,testUDT, testMap]

--- a/tests/example-autocreate-keyspace.hs
+++ b/tests/example-autocreate-keyspace.hs
@@ -2,7 +2,7 @@
 
 import Database.Cassandra.CQL
 import Control.Monad
-import Control.Monad.CatchIO
+import Control.Monad.Catch
 import Control.Monad.Trans (liftIO)
 import qualified Data.ByteString as B
 import Data.ByteString.Char8 (ByteString)
@@ -31,7 +31,7 @@ ignoreDropFailure :: Cas () -> Cas ()
 ignoreDropFailure code = code `catch` \exc -> case exc of
     ConfigError _ _ -> return ()  -- Ignore the error if the table doesn't exist
     Invalid _ _ -> return ()
-    _               -> throw exc
+    _               -> throwM exc
 
 main = do
     -- let auth = Just (PasswordAuthenticator "cassandra" "cassandra")


### PR DESCRIPTION
A ByteString is a sequence of bytes, but Cassandra ascii is a sequence of ASCII characters, which are defined to be in only the lower half of the byte range. This makes the mapping of ByteString partial, because ByteString is designed to storage the whole range.

This PR changes the mapping of ByteString toward the Cassandra blob type, which does support all ByteStrings. ByteStrings that have only ASCII in them now become the 'exceptional' type. This is a good thing, because ASCII ByteStrings are *not* normal ByteStrings, as they are supposed to only contain bytes in the ASCII range. It is a good idea to make this visible in the types.

As this is a breaking change, I have described the required action on the user's part in the changelog.